### PR TITLE
Fix issue with context append after `log` is called

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    amaysim_logger (1.0.0)
+    amaysim_logger (1.0.4)
       activesupport
       request_store (~> 1.3)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    amaysim_logger (1.0.4)
+    amaysim_logger (1.1.0)
       activesupport
       request_store (~> 1.3)
 

--- a/lib/amaysim_logger.rb
+++ b/lib/amaysim_logger.rb
@@ -130,7 +130,7 @@ class AmaysimLogger
         msg = params[:msg]
         params[:msg] = msg.is_a?(Hash) ? format_params(msg, false) : params[:msg].to_s.strip
       end
-      filtered_params = KeywordFilter.filter(params, filtered_keywords)
+      filtered_params = KeywordFilter.filter(log_context.merge(params), filtered_keywords)
       convert_to_string ? filtered_params.to_json : filtered_params
     end
   end

--- a/lib/amaysim_logger.rb
+++ b/lib/amaysim_logger.rb
@@ -88,7 +88,7 @@ class AmaysimLogger
         e = log_msg[:exception]
         log_msg.delete(:exception)
         log_exception(e, log_msg)
-        log_msg[:exception_backtrace] = e.backtrace.join('\n')
+        log_msg[:exception_backtrace] = e.backtrace
       end
 
       create_log_params(log_msg.delete(:msg), log_msg, log_level)

--- a/lib/amaysim_logger.rb
+++ b/lib/amaysim_logger.rb
@@ -1,9 +1,9 @@
+require 'json'
+require 'request_store'
 require 'active_support/logger'
 require 'active_support/core_ext/module/delegation'
-require 'json'
 require 'active_support/core_ext/time/conversions'
 require 'active_support/core_ext/time/zones'
-require 'request_store'
 require 'amaysim_logger/keyword_filter'
 
 # rubocop:disable Metrics/ClassLength
@@ -88,7 +88,6 @@ class AmaysimLogger
         e = log_msg[:exception]
         log_msg.delete(:exception)
         log_exception(e, log_msg)
-        log_msg[:exception_backtrace] = e.backtrace
       end
 
       create_log_params(log_msg.delete(:msg), log_msg, log_level)
@@ -123,6 +122,7 @@ class AmaysimLogger
       log_params[:msg] = e.message unless log_params.key?(:msg)
       log_params[:exception_class] = e.class.name
       log_params[:exception_message] = e.message
+      log_params[:exception_backtrace] = e.backtrace.first(20)
     end
 
     def format_params(params, convert_to_string = true)

--- a/lib/amaysim_logger/correlation_id_helper.rb
+++ b/lib/amaysim_logger/correlation_id_helper.rb
@@ -6,13 +6,7 @@ class AmaysimLogger
     extend ActiveSupport::Concern
 
     def correlation_id
-      @correlation_id ||= request.headers['CORRELATION-ID'] || new_correlation_id
-    end
-
-    private
-
-    def new_correlation_id
-      SecureRandom.uuid
+      @correlation_id ||= request.headers['CORRELATION-ID'] || request.uuid
     end
   end
 end

--- a/lib/amaysim_logger/keyword_filter.rb
+++ b/lib/amaysim_logger/keyword_filter.rb
@@ -22,7 +22,7 @@ class AmaysimLogger
           elsif val.is_a?(Hash)
             result[key] = filter_hash(val, filtered_keywords)
           elsif val.is_a?(Array)
-            result[key] = val.map { |entry| filter_hash(entry, filtered_keywords) }
+            result[key] = val.map { |entry| filter(entry, filtered_keywords) }
           elsif val.is_a?(String)
             result[key] = filter_xml(val, filtered_keywords)
           end

--- a/lib/amaysim_logger/keyword_filter.rb
+++ b/lib/amaysim_logger/keyword_filter.rb
@@ -17,15 +17,13 @@ class AmaysimLogger
       def filter_hash(content, filtered_keywords)
         result = content.clone
         result.each do |key, val|
-          if to_lower_case(filtered_keywords).include?(key.to_s.downcase)
-            result[key] = MASK
-          elsif val.is_a?(Hash)
-            result[key] = filter_hash(val, filtered_keywords)
-          elsif val.is_a?(Array)
-            result[key] = val.map { |entry| filter(entry, filtered_keywords) }
-          elsif val.is_a?(String)
-            result[key] = filter_xml(val, filtered_keywords)
-          end
+          result[key] = if to_lower_case(filtered_keywords).include?(key.to_s.downcase)
+                          MASK
+                        elsif val.is_a?(Array)
+                          val.map { |entry| filter(entry, filtered_keywords) }
+                        else
+                          filter(val, filtered_keywords)
+                        end
         end
         result
       end

--- a/lib/amaysim_logger/version.rb
+++ b/lib/amaysim_logger/version.rb
@@ -1,3 +1,3 @@
 class AmaysimLogger
-  VERSION = '1.0.4'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/spec/amaysim_logger/rails_controller_helper_spec.rb
+++ b/spec/amaysim_logger/rails_controller_helper_spec.rb
@@ -1,5 +1,6 @@
 require 'amaysim_logger/rails_controller_helper'
 require 'action_controller'
+require 'timecop'
 
 # rubocop:disable RSpec/MessageSpies
 # rubocop:disable RSpec/VerifiedDoubles
@@ -26,21 +27,17 @@ class AmaysimLogger
 
     describe '#log_request' do
       context 'when correlation-id not provided by HTTP header' do
-        before do
-          allow(SecureRandom).to receive(:uuid).and_return('generated-uuid')
-        end
-
         # rubocop:disable RSpec/ExampleLength
         it 'logs the http request with a generated correlation id' do
           log = {
-            msg: 'Web request',
-            log_timestamp: start_time,
-            log_level: 'debug',
             request_id: 'uuid',
             ip: '1.2.3.4',
             user_agent: 'Chrome',
             endpoint: 'http://amaysim.com.au',
-            correlation_id: 'generated-uuid',
+            correlation_id: 'uuid',
+            msg: 'Web request',
+            log_timestamp: start_time,
+            log_level: 'debug',
             start_time: start_time,
             end_time: end_time,
             duration: 10.0
@@ -60,14 +57,14 @@ class AmaysimLogger
 
         it 'logs the http request with the provided correlation id' do
           log = {
-            msg: 'Web request',
-            log_timestamp: start_time,
-            log_level: 'debug',
             request_id: 'uuid',
             ip: '1.2.3.4',
             user_agent: 'Chrome',
             endpoint: 'http://amaysim.com.au',
             correlation_id: 'provided-uuid',
+            msg: 'Web request',
+            log_timestamp: start_time,
+            log_level: 'debug',
             start_time: start_time,
             end_time: end_time,
             duration: 10.0

--- a/spec/amaysim_logger_spec.rb
+++ b/spec/amaysim_logger_spec.rb
@@ -272,16 +272,16 @@ RSpec.describe AmaysimLogger do
   describe 'include specific params from the request' do
     let(:log_msg) do
       {
-        msg: message,
-        log_timestamp: timestamp,
-        log_level: log_level,
         msn: 'log this',
         session_token: 'log this',
         request_id: 'log this',
         ip: 'log this',
         endpoint: 'log this',
         client_id: 'log this',
-        phone_id: 'log this'
+        phone_id: 'log this',
+        msg: message,
+        log_timestamp: timestamp,
+        log_level: log_level
       }.to_json
     end
 
@@ -318,7 +318,7 @@ RSpec.describe AmaysimLogger do
           log_level: 'error',
           exception_class: exception_class,
           exception_message: exception_message,
-          exception_backtrace: exception_backtrace.join('\n')
+          exception_backtrace: exception_backtrace
         }.to_json
       end
 
@@ -336,7 +336,7 @@ RSpec.describe AmaysimLogger do
           log_level: 'error',
           exception_class: exception_class,
           exception_message: exception_message,
-          exception_backtrace: exception_backtrace.join('\n')
+          exception_backtrace: exception_backtrace
         }.to_json
       end
 

--- a/spec/amaysim_logger_spec.rb
+++ b/spec/amaysim_logger_spec.rb
@@ -224,17 +224,24 @@ RSpec.describe AmaysimLogger do
           start_time: timestamp,
           exception_class: 'RuntimeError',
           exception_message: 'stinky things happen',
+          exception_backtrace: ['backtrace'],
           end_time: '2016-01-22 15:46:32 +1100 AEDT',
           duration: 10.0
         }.to_json
       end
 
+      let(:exception) do
+        RuntimeError.new('stinky things happen')
+      end
+
       let(:stinky_thing) do
         described_class.info(msg: message) do
           Timecop.freeze(end_time)
-          raise 'stinky things happen'
+          raise exception
         end
       end
+
+      before { allow(exception).to receive(:backtrace) { ['backtrace'] } }
 
       it 'logs end_log_msg on exception' do
         expect(logger).to receive(:info).with end_log_msg


### PR DESCRIPTION
* ensure getting all context data after yield	
* use request uuid for correlation ID instead of new uuid
* get full backtrace as array instead